### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:12-slim as build
+
+COPY . /pla-util
+RUN apt update && \
+    apt install -y gprbuild gnat git libpcap-dev && \
+    cd pla-util && \
+    gprbuild -p -P pla_util.gpr
+
+FROM debian:12-slim
+
+# Install all dependencies for running `pla-util`, and net-tools to have access to `ifconfig`.
+RUN apt update && apt install -y \
+    libgnat-12 \
+    libgpg-error0 \
+    liblz4-1 \
+    libzstd1 \
+    liblzma5 \
+    libgcrypt20 \
+    libcap2 \
+    libsystemd0 \
+    libpcap0.8 \
+    libdbus-1-3  \
+    libgcc-s1 \
+    net-tools
+
+COPY --from=build /pla-util/bin/pla-util /bin


### PR DESCRIPTION
Add a Dockerfile that builds `pla-util` from the checked-out repository and provides a minimal runtime image that contains all runtime dependencies but not the full build environment.

This Dockerfile is ideal to run on e.g. Raspberry Pi, without the need to install a full ADA development environment.

Cross-compilation via `docker buildx` works as well. Tested for Linux `x86_64`, `arm64` and `arm/v7`.

```shell
docker buildx build -t pla-util --builder=container --platform=linux/x86_64,linux/arm64,linux/arm/v7 --push .
```

This is what I'm using it for: https://peanball.net/2023/08/powerline-monitoring/